### PR TITLE
Create a lambda function to hit Bedrock API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Overview.md
+ghost-onboarder/.venv
+ghost-onboarder/.DS_Store
+../.DS_Store

--- a/ghost-onboarder/cli/lambda_function.py
+++ b/ghost-onboarder/cli/lambda_function.py
@@ -1,0 +1,37 @@
+'''Calls a public lambda endpoint which is configured to hit Bedrock API configured with our Claude model.'''
+
+import json, boto3, os
+
+REGION = "us-east-1"
+MODEL_ID = "anthropic.claude-3-sonnet-20240229-v1:0"
+
+client = boto3.client("bedrock-runtime", region_name=REGION)
+
+def lambda_handler(event, context):
+    try:
+        body = json.loads(event.get("body") or "{}")
+        msg = body.get("message", "")
+        if not msg:
+            return {"statusCode": 400, "body": "Missing 'message'."}
+
+        resp = client.converse(
+            modelId=MODEL_ID,
+            messages=[{"role": "user", "content": [{"text": msg}]}],
+            inferenceConfig={"maxTokens": 400, "temperature": 0.3},
+        )
+
+        output = "".join(c.get("text","") for c in resp["output"]["message"]["content"])
+        return {
+            "statusCode": 200,
+            "headers": {
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": "application/json",
+            },
+            "body": json.dumps({"reply": output}),
+        }
+    except Exception as e:
+        return {
+            "statusCode": 500,
+            "headers": {"Access-Control-Allow-Origin": "*"},
+            "body": json.dumps({"error": str(e)}),
+        }


### PR DESCRIPTION
- Added a couple files to .gitignore
- Added a lambda function to receive HTTP request, hit Bedrock API, return model output
   - Model can be modified in the lambda function
   - Other services in AWS (if needed) can be added here later too

Pros: Users don't have to deal with provisioning their own API keys
Cons: Dependent on our $125 free credits on AWS. Avoid spamming high token requests
